### PR TITLE
chore: change wording of Managed -> Created

### DIFF
--- a/gh_org_mgr/_gh_org.py
+++ b/gh_org_mgr/_gh_org.py
@@ -720,7 +720,7 @@ class GHorg:  # pylint: disable=too-many-instance-attributes, too-many-lines
                             try:
                                 repo = self.org.create_repo(
                                     name=repo_name,
-                                    description="Managed by github-org-manager",
+                                    description="Created by github-org-manager",
                                     private=True,
                                     has_issues=True,
                                     auto_init=True,


### PR DESCRIPTION
### **User description**
Updated from managed to created to help avoid any confusion around it actively managing anything outside of permissions of the repo.


___

### **PR Type**
Other


___

### **Description**
- Changed repository description from "Managed" to "Created"

- Updated wording to avoid confusion about active management


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_gh_org.py</strong><dd><code>Update repository description wording</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gh_org_mgr/_gh_org.py

<ul><li>Updated repository description from "Managed by github-org-manager" to <br>"Created by github-org-manager"<br> <li> Added missing newline at end of file</ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/github-org-manager/pull/4/files#diff-649422064c023d72b102a6d4120d5e7a07ecfd6421f73d1e74b9c240a0fc90e8">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

